### PR TITLE
Small language edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,34 @@
-# Lock it In 
+# Lock it In
+
+In the best engineering organizations, continuous learning is part of the software development and deployment cycle. This is achieved by team leads who cultivate a safe learning environment, and those who use teaching techniques to speed up the learning of their junior and mid-level engineers.
+
+In this interactive workshop, you'll learn and practice 3 high-impact teaching techniques from Doug Lemov's manual [Practice Perfect](https://www.amazon.com/Practice-Perfect-Rules-Getting-Better/dp/111821658X). You'll leave the workshop ready to coach your team and mentor with confidence, using the techniques [Lock It In](https://github.com/relentful/Lock-It-In), Analyze the Game, [Replace Your Purpose with an Objective](https://github.com/relentful/Replace-Your-Purpose-with-an-Objective).
+
+This workshop is designed for anyone who wants to help foster the development and growth of other engineers. Executives who are thinking about how to build and grow their software teams, Senior Engineers who want to coach and teach engineers with confidence and junior engineers who want to get better at coaching themselves and their peers.
 
 ## Outcomes
-_By the end of this workshop, you will:_ 
+_By the end of this workshop, you will:_
 1. Demonstrate three ways of asking someone to ‘Lock It In’
-1. Describe the purpose of using ‘Lock It In’ with a mentee or direct report 
-1. Demonstrate checking for understanding by using one of the ‘Lock it In’ prompts 
-1. (Stretch) Identify scenarios where you want your mentee to prioritize feedback vs. summarize or describe their next action 
+1. Describe the purpose of using ‘Lock It In’ with a mentee or direct report
+1. Demonstrate checking for understanding by using one of the ‘Lock it In’ prompts
+1. (Stretch) Identify scenarios where you want your mentee to prioritize feedback vs. summarize or describe their next action
 
 
-### Lock it In 
+### Lock it In
 * Rule 30 from [Practice Perfect](https://www.amazon.com/Practice-Perfect-Rules-Getting-Better/dp/111821658X)
-* A technique that allows you to check the understanding of the person you're working with. 
+* A technique that allows you to check the understanding of the person you're working with.
 
-### Lock it In Prompts 
-**Summarize the Feedback** 
+### Lock it In Prompts
+**Summarize the Feedback**
 * "Tell me what I told you."
 * "Let's both check our understanding…”
 * “Let’s have you replay replay that…”
 * “Will you play that back?”
-* “Let’s bottom line what we’ve talked about…” 
+* “Let’s bottom line what we’ve talked about…”
 
-**Prioritize Feedback** 
+**Prioritize Feedback**
 * "What's the most important thing we just talked about?"
 
-**Next Action** 
+**Next Action**
 * "Tell me the next thing you're going to do."
 * "What will you do the next time you encounter this challenge?"
-

--- a/assessment-1.md
+++ b/assessment-1.md
@@ -1,9 +1,9 @@
-# Assessment 1 
+# Assessment 1
 
-## Scenario: 
+## Scenario:
 
-You are wrapping up a weekly one-on-one with someone who reports directly to you. They have finished talking through their list of what’s gone well and poorly during the week, and you are wrapping up your feedback on their week. The most important thing that this person should understand is that in the next 24 hours, they need to alter the language they use in the comments section of a code review. During the last week, they unintentionally upset one of their colleagues by leaving a comment that said, ‘this code is really messy, you need to clean it up.’ You would like this developer apologize to their colleague, and to edit their comment so it is more neutral in tone and describes what the person requesting the review should change, something like, “This function is 28 lines long, and it performs multiple transformations on the input. Can you break this out into multiple functions, each of which only does one thing? Remember our engineering team quarterly goal of writing brief, modular functions.” 
+You are wrapping up a weekly one-on-one with someone who reports directly to you. The most important thing that this person should understand is that in the next 24 hours, they need to alter the language they use in the comments section of a code review. During the last week, they unintentionally upset one of their colleagues by leaving a comment that said, ‘this code is really messy, you need to clean it up.’ You would like this developer apologize to their colleague, and to edit their comment so it is more neutral in tone and clearly describes what should be changed. As an example, “This function is 28 lines long, and it performs multiple transformations on the input. Can you break this out into multiple functions, each of which only does one thing? Remember our engineering team quarterly goal of writing brief, modular functions.”
 
-## Tasks: 
-1. Describe what want from your check for understanding. 
-1. Show how you will you wrap up your feedback and Lock it In with this person.
+## Tasks:
+1. Describe the goal of your feedback
+1. Show how you will you wrap up your feedback and "Lock it In" with this person

--- a/assessment-2.md
+++ b/assessment-2.md
@@ -1,9 +1,9 @@
 # Assessment 2
 
-## Scenario: 
+## Scenario:
 
-You are having an open-ended one-on-one (no agenda) with someone you manage. They are a junior engineer, and they have been working hard to improve their technical, communication and planning and execution skills with success. They would be on track for a promotion soon, but they consistently undercut themselves in code reviews and customer syncs because of their lack of confidence. During your meeting, you lay out all the ways that they’ve improved in the last 9 months, and talk about how the things they say about themselves are undercutting their work and progress. During the next week, you’d like your colleague to notice when they engage in negative self-talk during the work day, with the goal of the week after replacing that with something more neutral. 
+You are having an open-ended one-on-one (no agenda) with a junior engineer you manage. They have been successfully working hard to improve their technical planning and execution skills. They would be on track for a promotion soon, but they consistently undercut themselves in code reviews and customer syncs because of their lack of confidence. During your meeting, you lay out all the ways that they’ve improved in the last 9 months, and how the things they say about themselves are undercutting their work and progress. During the next week, you’d like your colleague to notice when they engage in negative self-talk during the work day, with a goal for the following week of replacing that with something more neutral.
 
-## Tasks: 
-1. Describe what want from your check for understanding. 
-1. Show how you will you wrap up your feedback and Lock it In with this person.
+## Tasks:
+1. Describe the goal of your feedback.
+1. Show how you will you wrap up your feedback and "Lock it In" with this person

--- a/assessment-3.md
+++ b/assessment-3.md
@@ -1,10 +1,9 @@
-# Assessment 3 
+# Assessment 3
 
-## Scenario: 
+## Scenario:
 
-You are wrapping up a weekly sync with a client, and you and the client have agreed on multiple next steps. You want to ensure that you both of you have a shared understanding of the set of action items. 
+You are wrapping up a weekly sync with a client, and you and the client have agreed on multiple next steps. You want to ensure that you both of you have a shared understanding of the set of action items.
 
-## Tasks: 
-1. Describe what want from your check for understanding. 
-1. Show how you ask your client to summarize their next steps 
-
+## Tasks:
+1. Describe the goal of your communcation
+1. Show how you ask your client to summarize their next steps

--- a/rubric.md
+++ b/rubric.md
@@ -1,8 +1,8 @@
-# Rubric 
+# Rubric
 
-While checking for understanding, the person does the following: 
+While checking for understanding, the person does the following:
 
-* [ ] Identifies the goal of the feedback (a summary, prioritizing a piece of feedback or hearing the person describe their next action) 
-* [ ] Uses an appropriate ‘Lock it In’ prompt 
-* [ ] Tells the person what they understood correctly, and what misconceptions you heard
+* [ ] Identifies the goal of the feedback (a summary, prioritizing a piece of feedback or hearing the person describe their next action)
+* [ ] Uses an appropriate ‘Lock it In’ prompt
+* [ ] Confirms with the person what they understood correctly, and what misconceptions were expressed
 * [ ] (optional) Repeats the Lock it In prompt


### PR DESCRIPTION
Just a few minor language edits:
- Changed "Describe what want from your check for understanding." to "Describe the goal of your feedback"
- Removed some extra/unnecessary words from assessment descriptions
- Added the workshop's description for larger context when repo is viewed independently
- Editor removed trailing whitespace